### PR TITLE
[jsk_topic_tools/HzMeasureNodelet] Add diagnostics to monitor hz

### DIFF
--- a/doc/jsk_topic_tools/class/hz_measure_nodelet.md
+++ b/doc/jsk_topic_tools/class/hz_measure_nodelet.md
@@ -1,0 +1,35 @@
+# HzMeasureNodelet (C++)
+
+## Description
+
+This node publishes `hz` of target topic and `diagnostics`.
+
+User can specify `~warning_hz` param.
+
+If target `hz` is smaller than `~warning_hz`, this node outputs `diagnostics` at `WARN` level (if `~use_warn` is `True`) or `ERROR` level.
+
+
+## Subscribing Topic
+
+- `~input` (`AnyMsg`):
+
+    Target topic.
+
+## Publishing Topic
+
+- `~output` (`std_msgs::Float32`):
+
+    Target topic's `hz`.
+
+- `~diagnostics` (`diagnostic_msgs::DiagnosticArray`):
+
+    Diagnostic messages.
+
+## Parameter
+- `~message_num` (`Int`, default: `10`):
+
+    Calculate `hz` from the arrival times of `~message_num` topics.
+
+- `~use_warn` (Bool, default: `False`):
+
+    If this parameter is enabled, diagnostic messages on failure is displayed on `WARN` level instead of `ERROR` level.

--- a/jsk_topic_tools/include/jsk_topic_tools/hz_measure_nodelet.h
+++ b/jsk_topic_tools/include/jsk_topic_tools/hz_measure_nodelet.h
@@ -39,6 +39,8 @@
 #include <nodelet/nodelet.h>
 #include <topic_tools/shape_shifter.h>
 
+#include "jsk_topic_tools/timered_diagnostic_updater.h"
+
 #include <queue>
 
 namespace jsk_topic_tools
@@ -50,12 +52,34 @@ namespace jsk_topic_tools
     virtual void onInit();
   protected:
     int average_message_num_;
+    double hz_;
+    double warning_hz_;
     std::queue<ros::Time> buffer_;
     ros::Publisher hz_pub_;
     ros::Subscriber sub_;
     ros::NodeHandle pnh_;
     virtual void inputCallback(const boost::shared_ptr<topic_tools::ShapeShifter const>& msg);
-    
+
+    /** @brief
+     * Method which is called periodically.
+     *
+     * In default, it check vitality of vital_checker_ and if vital_checker_
+     * is not poked for seconds, diagnostic status will be ERROR.
+     * @param stat Modofy stat to change status of diagnostic information.
+     */
+    virtual void updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+
+    /** @brief
+     * True if summary is displayed as 'Warnings', otherwise it is displayed as 'Errors'
+     */
+    uint8_t diagnostic_error_level_;
+
+    /** @brief
+     * Pointer to TimeredDiagnosticUpdater to call
+     * updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper&)
+     * periodically.
+     */
+    TimeredDiagnosticUpdater::Ptr diagnostic_updater_;
   private:
   };
 }


### PR DESCRIPTION
# What is this?

Enable publishing diagnostics on `HzMeasureNodelet`.
This PR also adds a document.
The difference from `sanity_diagnostics.py` is that you can ignore the communication overhead when using it with nodelet.

```
This node publishes `hz` of target topic and `diagnostics`.

User can specify `~warning_hz` param.

If target `hz` is smaller than `~warning_hz`, this node outputs `diagnostics` at `WARN` level (if `~use_warn` is `True`) or `ERROR` level.
```

## Use case

For example, use it when you want to monitor the topic in the nodelet.

![Screenshot 2022-06-07 23:11:17](https://user-images.githubusercontent.com/4690682/172409157-8491729c-3f77-40b7-b9c4-f9138ac30f67.png)

At first, the topic (`/head_camera/depth_registered/hw_registered/image_rect_raw`) like this works with normal hz.
If hz drops for some reason, it will output error level diagnostics as follows:

![Screenshot 2022-06-07 23:20:37](https://user-images.githubusercontent.com/4690682/172409545-f66800df-ca60-495c-82fe-1e2899c7d902.png)

Related to https://github.com/jsk-ros-pkg/jsk_common/pull/1743